### PR TITLE
[fix] 계정 검증 에러 raise 수정 완료

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -27,7 +27,4 @@ class LoginSerializer(serializers.Serializer):
         if not user: 
             raise serializers.ValidationError('Invalid User')
 
-        if not user.is_active:
-            raise serializers.ValidationError('This user has been deactivated')
-
         return {'user' : user}


### PR DESCRIPTION
### PR Type
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 기타 (기타인 경우 내용 입력 :  계정 검증 메세지 수정) 

### 해당 PR의 목적
- 계정(email/password) 검증 기능 수정 

### 해당 PR 사유
- 로그인 시, 계정 검증 에러 메세지 중 `is_active` part 삭제 (`authenticate()`로 인해, 해당 part가 사용될 수 없음) 
- `invalid_user` 로 통일 